### PR TITLE
Add super-slow option for solar system sim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 *.sublime-project
 *.sublime-workspace
 .eslintcache
+package-lock.json

--- a/js/SceneryPhetFluent.ts
+++ b/js/SceneryPhetFluent.ts
@@ -119,6 +119,7 @@ addToMapIfDefined( 'keyboardHelpDialog_faucetControls_openFaucetBriefly', 'keybo
 addToMapIfDefined( 'keyboardHelpDialog_timingControls_timingControls', 'keyboardHelpDialog.timingControls.timingControlsStringProperty' );
 addToMapIfDefined( 'keyboardHelpDialog_timingControls_pauseOrPlayAction', 'keyboardHelpDialog.timingControls.pauseOrPlayActionStringProperty' );
 addToMapIfDefined( 'speed_fast', 'speed.fastStringProperty' );
+addToMapIfDefined( 'speed_superSlow', 'speed.superSlowStringProperty' );
 addToMapIfDefined( 'symbol_ohms', 'symbol.ohmsStringProperty' );
 addToMapIfDefined( 'symbol_resistivity', 'symbol.resistivityStringProperty' );
 addToMapIfDefined( 'wavelength', 'wavelengthStringProperty' );
@@ -377,7 +378,8 @@ const SceneryPhetFluent = {
   speed: {
     normalStringProperty: new FluentConstant( fluentSupport.bundleProperty, 'speed_normal', _.get( SceneryPhetStrings, 'speed.normalStringProperty' ) ),
     slowStringProperty: new FluentConstant( fluentSupport.bundleProperty, 'speed_slow', _.get( SceneryPhetStrings, 'speed.slowStringProperty' ) ),
-    fastStringProperty: new FluentConstant( fluentSupport.bundleProperty, 'speed_fast', _.get( SceneryPhetStrings, 'speed.fastStringProperty' ) )
+    fastStringProperty: new FluentConstant( fluentSupport.bundleProperty, 'speed_fast', _.get( SceneryPhetStrings, 'speed.fastStringProperty' ) ),
+    superSlowStringProperty: new FluentConstant( fluentSupport.bundleProperty, 'speed_superSlow', _.get( SceneryPhetStrings, 'speed.superSlowStringProperty' ) )
   },
   symbol: {
     ohmsStringProperty: new FluentConstant( fluentSupport.bundleProperty, 'symbol_ohms', _.get( SceneryPhetStrings, 'symbol.ohmsStringProperty' ) ),

--- a/js/SceneryPhetStrings.ts
+++ b/js/SceneryPhetStrings.ts
@@ -137,6 +137,7 @@ type StringsType = {
     'normalStringProperty': LocalizedStringProperty;
     'slowStringProperty': LocalizedStringProperty;
     'fastStringProperty': LocalizedStringProperty;
+    'superSlowStringProperty': LocalizedStringProperty;
   };
   'symbol': {
     'ohmsStringProperty': LocalizedStringProperty;

--- a/js/TimeSpeed.ts
+++ b/js/TimeSpeed.ts
@@ -16,6 +16,7 @@ export default class TimeSpeed extends EnumerationValue {
   public static readonly FAST = new TimeSpeed();
   public static readonly NORMAL = new TimeSpeed();
   public static readonly SLOW = new TimeSpeed();
+  public static readonly SUPER_SLOW = new TimeSpeed();
 
   // Gets a list of keys, values and mapping between them. For use in EnumerationProperty and PhET-iO
   public static readonly enumeration = new Enumeration( TimeSpeed );

--- a/js/TimeSpeedRadioButtonGroup.ts
+++ b/js/TimeSpeedRadioButtonGroup.ts
@@ -36,6 +36,10 @@ SPEED_LABEL_MAP.set( TimeSpeed.SLOW, {
   stringProperty: SceneryPhetStrings.speed.slowStringProperty,
   tandemName: 'slowRadioButton'
 } );
+SPEED_LABEL_MAP.set( TimeSpeed.SUPER_SLOW, {
+  stringProperty: SceneryPhetStrings.speed.superSlowStringProperty,
+  tandemName: 'superSlowRadioButton'
+} );
 
 type SelfOptions = {
   radius?: number;

--- a/js/demo/components/demoTimeControlNode.ts
+++ b/js/demo/components/demoTimeControlNode.ts
@@ -47,7 +47,7 @@ export default function demoTimeControlNode( layoutBounds: Bounds2 ): Node {
   // a TimeControlNode with swapped layout for radio buttons with radio buttons wrapped in a panel
   const customTimeControlNode = new TimeControlNode( new BooleanProperty( true ), {
     timeSpeedProperty: new EnumerationProperty( TimeSpeed.SLOW ),
-    timeSpeeds: [ TimeSpeed.NORMAL, TimeSpeed.FAST, TimeSpeed.SLOW ],
+    timeSpeeds: [ TimeSpeed.NORMAL, TimeSpeed.FAST, TimeSpeed.SLOW, TimeSpeed.SUPER_SLOW ],
     speedRadioButtonGroupPlacement: 'left',
     flowBoxSpacing: 40,
     enabledProperty: enabledProperty

--- a/scenery-phet-strings_en.json
+++ b/scenery-phet-strings_en.json
@@ -317,6 +317,9 @@
   "speed.fast": {
     "value": "Fast"
   },
+  "speed.superSlow": {
+    "value": "Super Slow"
+  },
   "symbol.ohms": {
     "value": "Ω"
   },

--- a/scenery-phet-strings_en.yaml
+++ b/scenery-phet-strings_en.yaml
@@ -104,6 +104,7 @@ keyboardHelpDialog.faucetControls.openFaucetBriefly:    Open faucet briefly
 keyboardHelpDialog.timingControls.timingControls:       Time Controls
 keyboardHelpDialog.timingControls.pauseOrPlayAction:    Pause or play action
 speed.fast:                                             Fast
+speed.superSlow:                                        Super Slow
 symbol.ohms:                                            Ω
 symbol.resistivity:                                     ρ
 comboBoxDisplay.valueUnits:                             '{{value}} {{units}}'


### PR DESCRIPTION
Adds a super-slow option that slows down the solar system simulation by 16x(instead of 4x like the regular slow mode does).

This PR was written from popular request from my classmates, who said that they wanted a way to slow down the simulation even more for increased precision.

Linked PRs:
1. https://github.com/phetsims/solar-system-common/pull/3

I'm not exactly sure if the babel changes need to be commited, since they can be autogenerated.